### PR TITLE
docs: capture Next.js baseline metrics pre-Astro-migration

### DIFF
--- a/metrics/baseline-2026-04-18.md
+++ b/metrics/baseline-2026-04-18.md
@@ -175,8 +175,21 @@ Pagefind postbuild: 0.044 s (search index over 15 pages, 3,440 words).
 
 ### GitHub Actions run time
 
-Not captured here — check the Actions tab for the last 5 `build` job durations
-and record the median as `ci_build_s` in the post-migration comparison.
+Last 5 deploys on `main` (via `gh run view`):
+
+| Run (PR)     | Build job | Deploy job | Total |
+|--------------|----------:|-----------:|------:|
+| #34 (tests)  |      44 s |       10 s |  54 s |
+| #32          |      35 s |        8 s |  43 s |
+| #31          |      38 s |       10 s |  48 s |
+| #30          |      38 s |       11 s |  49 s |
+| #29          |      31 s |        8 s |  39 s |
+| **Median**   |   **38 s**|    **10 s**| **48 s** |
+
+The build job includes `npm ci` + `npm run test:run` + `next build` + Pagefind +
+artifact upload; deploy is pure GitHub Pages publish. Only run #34 and later
+include the test step, so expect the "tests on" median to rise slightly as
+more data points come in.
 
 ---
 
@@ -248,7 +261,9 @@ If you only record a handful of numbers for comparison, use these:
 | Transitive deps                   |   235 |
 | `package-lock.json` lines         | 4,056 |
 | Clean install time                |  8.6 s |
-| Build time                        | 13.5 s |
+| Build time (local)                | 13.5 s |
+| CI build job (median of 5)        |   38 s |
+| CI total workflow (median of 5)   |   48 s |
 | Next.js imports in source         |     7 files |
 | Lighthouse perf (desktop / mobile home) | 100 / 100 |
 

--- a/metrics/baseline-2026-04-18.md
+++ b/metrics/baseline-2026-04-18.md
@@ -1,0 +1,230 @@
+# melgart.net — Next.js baseline (2026-04-18)
+
+Captured on `main` @ `609c197` (post-merge of PR #34 — includes Vitest suite).
+Host: miranda (Ubuntu 24.04). Live site: <https://melgart.net> (GitHub Pages).
+
+Purpose: establish numbers to diff against after a hypothetical Astro migration.
+The single most important metric is **JS shipped to the browser per page** —
+that is where Astro's islands model should show the largest drop.
+
+---
+
+## 1. Page weight (what a first-time visitor downloads)
+
+Measured against the deployed GitHub Pages build, gzip encoding.
+
+### Home page (`/`)
+
+| Asset                            | Raw bytes | Gzipped |
+|----------------------------------|----------:|--------:|
+| HTML document                    |     9,351 |   2,881 |
+| JS (10 chunks)                   |   424,464 | 136,269 |
+| CSS (2 files)                    |     2,490 |   1,048 |
+| **Total transfer (first visit)** | **436,305** | **140,198** |
+
+JS breakdown:
+- `framework-*.js` (React runtime): 140,017 raw / 44,883 gz
+- `main-*.js` (Next.js app shell):  116,292 raw / 33,976 gz
+- `polyfills-*.js`:                 112,594 raw / 39,479 gz
+- `chunks/426-*.js`:                 25,805 raw /  7,096 gz
+- `chunks/247-*.js`:                 16,058 raw /  6,028 gz
+- `pages/index-*.js`:                10,870 raw /  3,263 gz
+- Remaining (webpack runtime, manifests): ~2,828 raw / ~1,544 gz
+
+### Post page (`/posts/the-dispossessed`)
+
+| Asset                            | Raw bytes | Gzipped |
+|----------------------------------|----------:|--------:|
+| HTML document                    |    ~9,000 |   4,385 |
+| JS                               |   417,027 | 134,380 |
+| CSS                              |     1,244 |     708 |
+| **Total transfer (first visit)** | **~427,000** | **~139,500** |
+
+### What Astro would likely change
+
+Most of the JS above is React runtime + Next.js app shell — required to hydrate
+a page that is, in practice, static text. An Astro build of the same content
+would ship **~0 JS** on a plain blog post page (the Search island is the only
+interactive element and would ship only its own JS where present).
+
+Expected post-migration deltas:
+- **Plain post page JS: 134 kB gz → ~0 kB gz** (search not embedded there)
+- **Home page JS: 136 kB gz → ~5–15 kB gz** (just the Search island)
+
+---
+
+## 2. Build output (`out/`)
+
+After `npm run build` (+ Pagefind postbuild):
+
+```
+2.6M   out/                 (total)
+932K   out/images/          (post hero images — will not change)
+732K   out/pagefind/        (search index — will not change)
+672K   out/_next/           (framework JS/CSS — target for reduction)
+260K   out/posts/           (per-post HTML)
+ 12K   out/index.html
+  8K   out/{sports,posts}.html
+  4K   out/{saved-on-hosting,404}.html
+```
+
+By file type across entire output:
+
+| Type  |    Total | Files |
+|-------|---------:|------:|
+| .js   | 901,286 B |   21  |
+| .html | 260,931 B |   20  |
+| .json |  96,798 B |   18  |
+| .css  |  67,110 B |    6  |
+
+The `_next/` directory (672K) is the direct target of the migration. Images
+and Pagefind index are framework-agnostic.
+
+---
+
+## 3. Load performance (synthetic)
+
+Ran `curl` three times against each URL from miranda (Tailscale → public
+internet → GitHub Pages CDN). These numbers capture server response, not full
+page render — Lighthouse would be better but requires Chrome (see §7).
+
+### Home (`/`)
+| Run | TTFB | Total |
+|-----|-----:|------:|
+| 1   | 86 ms | 87 ms |
+| 2   | 91 ms | 91 ms |
+| 3   | 73 ms | 73 ms |
+
+### Post (`/posts/the-dispossessed`)
+| Run | TTFB | Total |
+|-----|-----:|------:|
+| 1   | 138 ms | 138 ms |
+| 2   |  77 ms |  78 ms |
+| 3   |  74 ms |  74 ms |
+
+These are fine — GitHub Pages CDN is fast. The interesting comparison for
+before/after isn't TTFB (which is a hosting concern, not a framework one), but
+**Largest Contentful Paint** and **Total Blocking Time**, which depend on how
+much JS must parse before the page becomes interactive. Those require
+Lighthouse — capture once Chrome is installed or from PageSpeed Insights web UI.
+
+---
+
+## 4. Repo complexity
+
+| Metric                             | Value    |
+|-----------------------------------|---------:|
+| Direct dependencies (`package.json`) |        8 |
+| Direct devDependencies            |        7 |
+| Transitive deps (`npm ls --all`)  |      235 |
+| `node_modules` size               |     597M |
+| `node_modules` top-level dirs     |      202 |
+| `package-lock.json`               | 4,056 lines |
+| Git-tracked files                 |       58 |
+| High-severity npm audit findings  |        1 |
+
+### Files by type (git-tracked)
+
+| Extension | Count |
+|-----------|------:|
+| .md   | 21 (15 posts + 3 test fixtures + CLAUDE, README, todo) |
+| .js   | 15 |
+| .jsx  |  4 (tests only) |
+| .css  |  5 |
+| .json |  3 |
+| .yml  |  1 |
+
+### Lines of code (source only, excluding node_modules/out/.next)
+
+Total: **6,601** across all tracked files.
+
+Notable files:
+- `utils/posts.js` — 63 lines (content pipeline)
+- `components/*.js` — 4 components (date, layout, injectMetadata, Search)
+- `tests/` — 6 test files, ~216 lines of test code, ~29 lines of fixtures
+
+### Next.js surface actually used
+
+7 source files import from `next/*`. Breakdown of imports:
+
+| Import            | Occurrences |
+|-------------------|------------:|
+| `next/head`       | 7 |
+| `next/link`       | 5 |
+| `next/image`      | 1 |
+| `next/router` etc | 0 |
+
+No use of API routes, middleware, server components, `getServerSideProps`,
+dynamic imports via `next/dynamic`, or any other Next-specific runtime features.
+Everything we use has a direct Astro equivalent or is obviated by Astro's
+Content Collections.
+
+---
+
+## 5. Build/install cost
+
+| Step                   | Wall clock | User  | Peak RSS |
+|------------------------|-----------:|------:|---------:|
+| `npm ci` (cold cache)  |     8.56 s | —     |   853 MB |
+| `npm run build`        |    13.51 s | 19.17 s |   451 MB |
+
+Build parallelizes across cores (152% CPU usage → effective wall clock of 13.5s
+despite 19.2s of user time).
+
+Pagefind postbuild: 0.044 s (search index over 15 pages, 3,440 words).
+
+### GitHub Actions run time
+
+Not captured here — check the Actions tab for the last 5 `build` job durations
+and record the median as `ci_build_s` in the post-migration comparison.
+
+---
+
+## 6. Lighthouse / PageSpeed Insights — **pending**
+
+Not captured on this run:
+- Chrome/Chromium not installed on miranda, so `lighthouse` CLI cannot run.
+- PageSpeed Insights API hit its anonymous daily quota.
+
+**To capture for the baseline**, open <https://pagespeed.web.dev/> from any
+device, enter `https://melgart.net/` and `https://melgart.net/posts/the-dispossessed`,
+and record the following (both desktop and mobile if convenient):
+
+- Performance score (0–100)
+- First Contentful Paint (s)
+- Largest Contentful Paint (s)
+- Total Blocking Time (ms)
+- Cumulative Layout Shift
+- Speed Index (s)
+- Accessibility score
+- Best Practices score
+- SEO score
+
+Then paste them into this file under a new "§6 Lighthouse" subsection so the
+post-migration snapshot has something to diff against.
+
+---
+
+## 7. Headline numbers (for quick diff)
+
+If you only record a handful of numbers for comparison, use these:
+
+| Metric                            | Value |
+|-----------------------------------|------:|
+| **Home page JS (gzip)**           | 136 kB |
+| **Post page JS (gzip)**           | 134 kB |
+| Home page total transfer (gzip)   | 140 kB |
+| Post page total transfer (gzip)   | 140 kB |
+| First Load JS shared (Next build) |  80 kB |
+| `out/_next/` size                 | 672 kB |
+| `node_modules` size               | 597 MB |
+| Transitive deps                   |   235 |
+| `package-lock.json` lines         | 4,056 |
+| Clean install time                |  8.6 s |
+| Build time                        | 13.5 s |
+| Next.js imports in source         |     7 files |
+| Lighthouse perf (desktop)         |   TBD |
+
+The big prediction: **JS shipped per post page drops from 134 kB → near zero**
+and **transitive deps drop by ~40%** (React + Next's transitive graph is the
+bulk of the 235). If those hold, the migration delivered what it was supposed to.

--- a/metrics/baseline-2026-04-18.md
+++ b/metrics/baseline-2026-04-18.md
@@ -180,28 +180,55 @@ and record the median as `ci_build_s` in the post-migration comparison.
 
 ---
 
-## 6. Lighthouse / PageSpeed Insights — **pending**
+## 6. Lighthouse / PageSpeed Insights
 
-Not captured on this run:
-- Chrome/Chromium not installed on miranda, so `lighthouse` CLI cannot run.
-- PageSpeed Insights API hit its anonymous daily quota.
+Captured via <https://pagespeed.web.dev/> (runs Lighthouse from Google's
+infrastructure — reproducible and what we'll re-run post-migration).
 
-**To capture for the baseline**, open <https://pagespeed.web.dev/> from any
-device, enter `https://melgart.net/` and `https://melgart.net/posts/the-dispossessed`,
-and record the following (both desktop and mobile if convenient):
+### Home (`/`)
 
-- Performance score (0–100)
-- First Contentful Paint (s)
-- Largest Contentful Paint (s)
-- Total Blocking Time (ms)
-- Cumulative Layout Shift
-- Speed Index (s)
-- Accessibility score
-- Best Practices score
-- SEO score
+| Metric                    | Mobile | Desktop |
+|---------------------------|-------:|--------:|
+| **Performance**           |    100 |     100 |
+| First Contentful Paint    |  0.8 s |   0.3 s |
+| Largest Contentful Paint  |  1.2 s |   0.7 s |
+| Total Blocking Time       |   0 ms |    0 ms |
+| Cumulative Layout Shift   |      0 |   0.014 |
+| Speed Index               |  0.8 s |   0.4 s |
+| **Accessibility**         |     96 |      96 |
+| **Best Practices**        |     96 |      96 |
+| **SEO**                   |    100 |     100 |
 
-Then paste them into this file under a new "§6 Lighthouse" subsection so the
-post-migration snapshot has something to diff against.
+### Post (`/posts/the-dispossessed`)
+
+| Metric                    | Mobile | Desktop |
+|---------------------------|-------:|--------:|
+| **Performance**           |    100 |     100 |
+| First Contentful Paint    |  0.8 s |   0.2 s |
+| Largest Contentful Paint  |  1.2 s |   0.4 s |
+| Total Blocking Time       |   0 ms |    0 ms |
+| Cumulative Layout Shift   |      0 |       0 |
+| Speed Index               |  0.8 s |   0.3 s |
+| **Accessibility**         |     94 |      94 |
+| **Best Practices**        |    100 |      96 |
+| **SEO**                   |    100 |     100 |
+
+### Interpretation
+
+Perf score is already 100 on both form factors — the site is fast enough that
+Astro can't beat it on a Lighthouse scorecard. The win there is 0 → 0, which
+isn't an improvement.
+
+Where Astro still wins is **what those same scores cost to achieve**: the
+current site spends 134 kB of gzipped JS to render static text, parsed on
+every first visit on every device. Astro would deliver the same 100 perf score
+while shipping ~0 kB of JS on a plain post page. That doesn't show up in
+Lighthouse — it shows up in battery, data plans, and low-end devices where
+Lighthouse's desktop/mobile synthetic runs don't stress the CPU enough to
+expose the difference.
+
+Non-perf scores (a11y 96, best-practices 96) are modest opportunities
+independent of framework — worth a separate look regardless of migration.
 
 ---
 
@@ -223,7 +250,7 @@ If you only record a handful of numbers for comparison, use these:
 | Clean install time                |  8.6 s |
 | Build time                        | 13.5 s |
 | Next.js imports in source         |     7 files |
-| Lighthouse perf (desktop)         |   TBD |
+| Lighthouse perf (desktop / mobile home) | 100 / 100 |
 
 The big prediction: **JS shipped per post page drops from 134 kB → near zero**
 and **transitive deps drop by ~40%** (React + Next's transitive graph is the

--- a/todo-list.md
+++ b/todo-list.md
@@ -1,4 +1,6 @@
 # Project To-dos
 - set up linting
 - I don't like that my photo is a circle. It should be like formatted even less
+- investigate the Lighthouse accessibility (94-96) and best-practices (96) gaps — framework-independent, likely alt text and/or contrast
+- revisit font choices
 


### PR DESCRIPTION
## Summary
- Records concrete before-numbers for the current Next.js 14 site so a future Astro migration has something to diff against.
- Captures page weight (gzipped, measured against live site), build output sizes, repo complexity (deps, LOC, framework surface), and build/install timings.
- Leaves a `§6 Lighthouse` placeholder — Chrome isn't installed on the dev server and the PSI anonymous API hit daily quota; to be filled in later from pagespeed.web.dev.

## Headline numbers
- **Home page**: 140 kB total gzipped transfer, **136 kB of that is JS**
- **Post page**: 140 kB total, **134 kB JS**
- Only 7 source files touch `next/*` APIs (`next/head`, `next/link`, `next/image`). No routing/middleware/server-component usage — the framework surface actually in use is tiny.
- `node_modules` 597 MB / 235 transitive deps / `package-lock.json` 4,056 lines
- Build: 13.5 s — Install (cold): 8.6 s

The file sets up the single most honest migration test: **if a post page doesn't drop from 134 kB JS to near-zero, Astro isn't earning its keep.**

## Test plan
- [ ] Open `metrics/baseline-2026-04-18.md` and skim §1 (page weight) + §7 (headline table) for sanity
- [ ] From phone: run https://pagespeed.web.dev/ against `https://melgart.net/` and `/posts/the-dispossessed`; paste desktop + mobile numbers into §6 before merging (or merge now and add in a follow-up commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)