### PR TITLE
ci: run build job on pull requests

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,6 +9,11 @@ on:
   push:
     branches: ["main"]
 
+  # Runs on pull requests targeting the default branch — build + tests
+  # only; the deploy job is gated to push events on main.
+  pull_request:
+    branches: ["main"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -71,8 +76,10 @@ jobs:
           path: ./dist
           include-hidden-files: true
 
-  # Deployment job
+  # Deployment job — only runs on push to main, not on PRs or manual
+  # dispatches against other branches.
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Adds a `pull_request` trigger to `.github/workflows/build-and-deploy.yml` so PRs targeting `main` run the build + test pipeline before merge. The `deploy` job is gated with `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` so only main pushes deploy.

## Why

PR #36 (Astro migration) had to be verified by manually dispatching the workflow against the feature branch — that's the gap this closes. From now on, the build job will run automatically on every PR and post the green/red checkmark in the Checks tab.

## Behavior matrix

| Event              | Branch        | Build | Deploy |
|--------------------|---------------|------:|-------:|
| `push`             | `main`        |   ✓   |   ✓    |
| `pull_request`     | targets main  |   ✓   |   ✗    |
| `workflow_dispatch`| `main`        |   ✓   |   ✓    |
| `workflow_dispatch`| other         |   ✓   |   ✗    |

This is slightly more restrictive than the previous behavior — yesterday's manual dispatch against `feature/astro-migration` ran the deploy job and got rejected by GitHub Pages environment protection. With this change, the deploy job is skipped before that rejection happens (cleaner, no error annotations).

## Self-validating

This PR is itself the first opportunity to test the new trigger. If the build check appears in the Checks tab for this PR, the change works.

## Test plan

- [ ] Build job runs automatically on this PR (visible in Checks tab)
- [ ] Build job: ✓ green
- [ ] Deploy job: skipped (not run)
- [ ] After merge: post-merge run on `main` runs both build and deploy as before