### PR TITLE
Update Duke sports achievements for 2025-26 seasons

### DIFF
--- a/data/sports-data.json
+++ b/data/sports-data.json
@@ -114,6 +114,14 @@
               {"type": "cbb_conference_championship", "description": "ACC Champions"},
               {"type": "final_four", "description": "Final Four"}
             ]
+          },
+          {
+            "year": 2026,
+            "achievements": [
+              { "type": "rival_victory", "opponent": "North Carolina", "points": 20, "description": "Beat UNC" },
+              { "type": "cbb_conference_championship", "points": 17, "description": "ACC Tournament Champions" },
+              { "type": "elite_eight", "points": 25, "description": "Elite Eight (lost to UConn 73-72)" }
+            ]
           }
         ]
       },
@@ -300,7 +308,8 @@
             "year": 2025,
             "achievements": [
               {"type": "rival_victory", "opponent":"North Carolina", "description": "Beat Carolina"},
-              {"type": "cfb_conference_championship", "description": "ACC Champions"}
+              {"type": "cfb_conference_championship", "description": "ACC Champions"},
+              {"type": "won_bowl_game", "points": 40, "description": "Won Sun Bowl 42-39 vs Arizona State"}
             ]
           }
         ]


### PR DESCRIPTION
## Summary
Updates Duke sports achievements in sports-data.json with recent accomplishments from the 2025-26 basketball season and 2025 football season.

## Changes
- Added Duke basketball 2026 season with three achievements:
  - Rival victory vs North Carolina (20 points)
  - ACC Tournament Championship (17 points)  
  - Elite Eight appearance, lost to UConn 73-72 (25 points)
- Added Sun Bowl victory to Duke football 2025 season:
  - Won Sun Bowl 42-39 vs Arizona State (40 points)

## Task
Implements plan from: state/tasks/update-sports-duke-2026.md

## Notes
All achievement types used existing point values from achievement_default_points schema. JSON syntax validated and site builds successfully. Tests pass.