### PR TITLE
Add /stats page + fix per-route attribution

### DIFF
--- a/scripts/build-stats.mjs
+++ b/scripts/build-stats.mjs
@@ -123,39 +123,70 @@ function getRouteFromPath(filePath) {
   return `/${dir}`;
 }
 
+// Pull the /_astro/* JS and CSS bundles a page actually links to. Astro
+// references hydrated-island code via component-url / renderer-url attributes
+// (and modulepreload links), so a fully static page references none and stays
+// tiny. Returns dist-relative paths (no leading slash) to match walked files.
+function extractAstroAssetRefs(htmlContent) {
+  const refs = new Set();
+  const re = /\/?_astro\/[A-Za-z0-9._-]+\.(?:js|css)/g;
+  let match;
+  while ((match = re.exec(htmlContent)) !== null) {
+    refs.add(match[0].replace(/^\//, ''));
+  }
+  return refs;
+}
+
 function analyzeRouteAssets(files) {
   const routeAssets = {};
 
-  // Initialize tracked routes
+  // Initialize tracked routes. Per-route totals measure page code (HTML plus
+  // the JS/CSS that page loads); images are reported site-wide in totalSizes.
   for (const route of TRACKED_ROUTES) {
     routeAssets[route] = {
       html: { raw: 0, gzipped: 0 },
       css: { raw: 0, gzipped: 0 },
       js: { raw: 0, gzipped: 0 },
-      images: { raw: 0, gzipped: 0 },
       total: { raw: 0, gzipped: 0 },
     };
   }
 
-  const addToRoute = (route, file) => {
-    const typeStats = routeAssets[route][file.type] || { raw: 0, gzipped: 0 };
-    typeStats.raw += file.raw;
-    typeStats.gzipped += file.gzipped;
-    routeAssets[route].total.raw += file.raw;
-    routeAssets[route].total.gzipped += file.gzipped;
+  // Index every file by its dist-relative path so referenced bundles can be
+  // looked up by the path that appears in the HTML.
+  const fileByPath = new Map();
+  for (const file of files) {
+    fileByPath.set(file.path.split(path.sep).join('/'), file);
+  }
+
+  const add = (route, type, raw, gzipped) => {
+    routeAssets[route][type].raw += raw;
+    routeAssets[route][type].gzipped += gzipped;
+    routeAssets[route].total.raw += raw;
+    routeAssets[route].total.gzipped += gzipped;
   };
 
-  for (const file of files) {
-    // Files under _astro/ are shared bundles (Astro runtime, hydrated islands)
-    // that a browser may load on any page. Attribute them to every tracked
-    // route so per-route totals reflect what's actually downloaded.
-    if (file.path.startsWith('_astro/') || file.path.startsWith('_astro' + path.sep)) {
-      for (const route of TRACKED_ROUTES) addToRoute(route, file);
-      continue;
-    }
+  // A shared bundle counts once per route even if several pages in that route
+  // (e.g. multiple posts rolled into /posts) reference it.
+  const countedByRoute = {};
+  for (const route of TRACKED_ROUTES) countedByRoute[route] = new Set();
 
+  for (const file of files) {
+    if (file.type !== 'html') continue;
     const route = getRouteFromPath(file.path);
-    if (routeAssets[route]) addToRoute(route, file);
+    if (!routeAssets[route]) continue;
+
+    // The page's own markup.
+    add(route, 'html', file.raw, file.gzipped);
+
+    // Plus only the bundles this page actually references.
+    const refs = extractAstroAssetRefs(fs.readFileSync(file.fullPath, 'utf8'));
+    for (const ref of refs) {
+      if (countedByRoute[route].has(ref)) continue;
+      countedByRoute[route].add(ref);
+      const asset = fileByPath.get(ref);
+      if (!asset) continue;
+      add(route, asset.type === 'css' ? 'css' : 'js', asset.raw, asset.gzipped);
+    }
   }
 
   return routeAssets;
@@ -229,7 +260,7 @@ function generateBuildStats() {
 
   // Generate statistics object
   const buildStats = {
-    schemaVersion: '1.0.0',
+    schemaVersion: '1.1.0',
     buildTimestamp,
     gitCommitSha,
     postCount,

--- a/scripts/build-stats.mjs
+++ b/scripts/build-stats.mjs
@@ -18,8 +18,9 @@ const FILE_TYPES = {
   images: ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.webp', '.avif', '.ico'],
 };
 
-// Routes we care about for per-route analysis
-const TRACKED_ROUTES = ['/', '/blog', '/sports', '/search'];
+// Routes we care about for per-route analysis. These mirror the real pages
+// Astro emits (each as <route>/index.html), not aspirational ones.
+const TRACKED_ROUTES = ['/', '/posts', '/sports', '/saved-on-hosting', '/stats'];
 
 function getFileType(filePath) {
   const ext = path.extname(filePath).toLowerCase();
@@ -96,19 +97,30 @@ function getInlinedCssStats(files) {
 }
 
 function getRouteFromPath(filePath) {
-  // Simple heuristic to map file paths to routes
-  // This may need refinement based on actual Astro output structure
+  // Astro emits each page as a directory with an index.html
+  // (e.g. sports/index.html, posts/artemis/index.html). Map a file to the
+  // route of the page directory that contains it.
 
-  if (filePath === 'index.html') return '/';
-  if (filePath.startsWith('blog/')) return '/blog';
-  if (filePath.startsWith('sports/')) return '/sports';
-  if (filePath.startsWith('search/') || filePath.includes('search')) return '/search';
+  // Normalize separators so this works regardless of platform.
+  const normalized = filePath.split(path.sep).join('/');
 
-  // Extract route from path
-  const withoutExt = filePath.replace(/\.[^/.]+$/, '');
-  const route = withoutExt === 'index' ? '/' : `/${withoutExt}`;
+  // The site root.
+  if (normalized === 'index.html') return '/';
 
-  return route;
+  // Drop a trailing index.html to get the page directory, otherwise use the
+  // file's own directory (covers non-html assets that sit beside a page).
+  const dir = normalized.endsWith('/index.html')
+    ? normalized.slice(0, -'/index.html'.length)
+    : normalized.replace(/\/[^/]*$/, '');
+
+  if (!dir) return '/';
+
+  // Roll individual blog posts (posts/<slug>) up into the /posts section so
+  // the blog reads as a single number rather than 15 separate routes.
+  const topSegment = dir.split('/')[0];
+  if (topSegment === 'posts') return '/posts';
+
+  return `/${dir}`;
 }
 
 function analyzeRouteAssets(files) {

--- a/src/data/build-stats.json
+++ b/src/data/build-stats.json
@@ -1,12 +1,12 @@
 {
-  "schemaVersion": "1.0.0",
-  "buildTimestamp": "2026-05-23T02:57:18.048Z",
-  "gitCommitSha": "c59000e3fe75ce9f12369bcda99825e16f0d8693",
+  "schemaVersion": "1.1.0",
+  "buildTimestamp": "2026-05-23T04:01:07.861Z",
+  "gitCommitSha": "b9e8094086fe2f73a6b92ce4dc478efd5ac84d00",
   "postCount": 15,
   "totalSizes": {
     "html": {
-      "raw": 172088,
-      "gzipped": 70577
+      "raw": 172628,
+      "gzipped": 70834
     },
     "css": {
       "raw": 0,
@@ -25,8 +25,8 @@
       "gzipped": 0
     },
     "total": {
-      "raw": 1301554,
-      "gzipped": 1059334
+      "raw": 1302094,
+      "gzipped": 1059591
     },
     "inlinedCss": {
       "raw": 24682,
@@ -44,16 +44,12 @@
         "gzipped": 0
       },
       "js": {
-        "raw": 166992,
-        "gzipped": 51742
-      },
-      "images": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 138274,
+        "gzipped": 44961
       },
       "total": {
-        "raw": 179859,
-        "gzipped": 56226
+        "raw": 151141,
+        "gzipped": 49445
       }
     },
     "/posts": {
@@ -66,16 +62,12 @@
         "gzipped": 0
       },
       "js": {
-        "raw": 166992,
-        "gzipped": 51742
-      },
-      "images": {
         "raw": 0,
         "gzipped": 0
       },
       "total": {
-        "raw": 306204,
-        "gzipped": 111243
+        "raw": 139212,
+        "gzipped": 59501
       }
     },
     "/sports": {
@@ -88,16 +80,12 @@
         "gzipped": 0
       },
       "js": {
-        "raw": 166992,
-        "gzipped": 51742
-      },
-      "images": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 157559,
+        "gzipped": 47754
       },
       "total": {
-        "raw": 177192,
-        "gzipped": 55086
+        "raw": 167759,
+        "gzipped": 51098
       }
     },
     "/saved-on-hosting": {
@@ -110,38 +98,30 @@
         "gzipped": 0
       },
       "js": {
-        "raw": 166992,
-        "gzipped": 51742
-      },
-      "images": {
         "raw": 0,
         "gzipped": 0
       },
       "total": {
-        "raw": 169928,
-        "gzipped": 52964
+        "raw": 2936,
+        "gzipped": 1222
       }
     },
     "/stats": {
       "html": {
-        "raw": 6873,
-        "gzipped": 2026
+        "raw": 7413,
+        "gzipped": 2283
       },
       "css": {
         "raw": 0,
         "gzipped": 0
       },
       "js": {
-        "raw": 166992,
-        "gzipped": 51742
-      },
-      "images": {
         "raw": 0,
         "gzipped": 0
       },
       "total": {
-        "raw": 173865,
-        "gzipped": 53768
+        "raw": 7413,
+        "gzipped": 2283
       }
     }
   },

--- a/src/data/build-stats.json
+++ b/src/data/build-stats.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "1.0.0",
-  "buildTimestamp": "2026-05-05T12:02:01.537Z",
-  "gitCommitSha": "ce95a62281c135747225e8fc5ce57b4dddbd22a7",
+  "buildTimestamp": "2026-05-23T02:57:18.048Z",
+  "gitCommitSha": "c59000e3fe75ce9f12369bcda99825e16f0d8693",
   "postCount": 15,
   "totalSizes": {
     "html": {
-      "raw": 165154,
-      "gzipped": 68541
+      "raw": 172088,
+      "gzipped": 70577
     },
     "css": {
       "raw": 0,
@@ -25,53 +25,57 @@
       "gzipped": 0
     },
     "total": {
-      "raw": 1294620,
-      "gzipped": 1057298
+      "raw": 1301554,
+      "gzipped": 1059334
+    },
+    "inlinedCss": {
+      "raw": 24682,
+      "gzipped": 1191
     }
   },
   "routeAssets": {
     "/": {
       "html": {
-        "raw": 12807,
-        "gzipped": 4474
+        "raw": 12867,
+        "gzipped": 4484
       },
       "css": {
         "raw": 0,
         "gzipped": 0
       },
       "js": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 166992,
+        "gzipped": 51742
       },
       "images": {
         "raw": 0,
         "gzipped": 0
       },
       "total": {
-        "raw": 12807,
-        "gzipped": 4474
+        "raw": 179859,
+        "gzipped": 56226
       }
     },
-    "/blog": {
+    "/posts": {
       "html": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 139212,
+        "gzipped": 59501
       },
       "css": {
         "raw": 0,
         "gzipped": 0
       },
       "js": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 166992,
+        "gzipped": 51742
       },
       "images": {
         "raw": 0,
         "gzipped": 0
       },
       "total": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 306204,
+        "gzipped": 111243
       }
     },
     "/sports": {
@@ -84,41 +88,63 @@
         "gzipped": 0
       },
       "js": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 166992,
+        "gzipped": 51742
       },
       "images": {
         "raw": 0,
         "gzipped": 0
       },
       "total": {
-        "raw": 10200,
-        "gzipped": 3344
+        "raw": 177192,
+        "gzipped": 55086
       }
     },
-    "/search": {
+    "/saved-on-hosting": {
       "html": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 2936,
+        "gzipped": 1222
       },
       "css": {
         "raw": 0,
         "gzipped": 0
       },
       "js": {
-        "raw": 0,
-        "gzipped": 0
+        "raw": 166992,
+        "gzipped": 51742
       },
       "images": {
         "raw": 0,
         "gzipped": 0
       },
       "total": {
+        "raw": 169928,
+        "gzipped": 52964
+      }
+    },
+    "/stats": {
+      "html": {
+        "raw": 6873,
+        "gzipped": 2026
+      },
+      "css": {
         "raw": 0,
         "gzipped": 0
+      },
+      "js": {
+        "raw": 166992,
+        "gzipped": 51742
+      },
+      "images": {
+        "raw": 0,
+        "gzipped": 0
+      },
+      "total": {
+        "raw": 173865,
+        "gzipped": 53768
       }
     }
   },
-  "fileCount": 30,
+  "fileCount": 31,
   "generatedBy": "scripts/build-stats.mjs"
 }

--- a/src/data/build-stats.json
+++ b/src/data/build-stats.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "1.1.0",
-  "buildTimestamp": "2026-05-23T04:01:07.861Z",
-  "gitCommitSha": "b9e8094086fe2f73a6b92ce4dc478efd5ac84d00",
+  "buildTimestamp": "2026-05-23T15:35:29.787Z",
+  "gitCommitSha": "b32951b2691a825c59b16aa428067607502b4ef3",
   "postCount": 15,
   "totalSizes": {
     "html": {
-      "raw": 172628,
-      "gzipped": 70834
+      "raw": 172649,
+      "gzipped": 70832
     },
     "css": {
       "raw": 0,
@@ -25,8 +25,8 @@
       "gzipped": 0
     },
     "total": {
-      "raw": 1302094,
-      "gzipped": 1059591
+      "raw": 1302115,
+      "gzipped": 1059589
     },
     "inlinedCss": {
       "raw": 24682,
@@ -108,8 +108,8 @@
     },
     "/stats": {
       "html": {
-        "raw": 7413,
-        "gzipped": 2283
+        "raw": 7434,
+        "gzipped": 2281
       },
       "css": {
         "raw": 0,
@@ -120,8 +120,8 @@
         "gzipped": 0
       },
       "total": {
-        "raw": 7413,
-        "gzipped": 2283
+        "raw": 7434,
+        "gzipped": 2281
       }
     }
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -122,6 +122,9 @@ const formatDate = (dateString) => {
         <li class="listItem">
           <a href="/saved-on-hosting">Money Saved Self Hosting</a>
         </li>
+        <li class="listItem">
+          <a href="/stats">Site Stats</a>
+        </li>
       </ul>
     </section>
     <br />

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -24,9 +24,9 @@ const { totalSizes, routeAssets, postCount, fileCount, buildTimestamp, gitCommit
 const inlinedCss = totalSizes.inlinedCss; // added 2026-05; may be absent in older builds
 const shortSha = gitCommitSha ? gitCommitSha.slice(0, 7) : null;
 
-// By-type rows for the main breakdown. The literal `css` bucket is omitted —
-// Astro inlines CSS into <style> tags, so it always reads 0; the real number
-// is surfaced separately as inlinedCss below.
+// By-type rows for the main breakdown. The literal `css` bucket is omitted
+// because Astro inlines CSS into <style> tags, so it always reads 0; the real
+// number is surfaced separately as inlinedCss below.
 const typeLabels = { html: 'HTML', js: 'JavaScript', images: 'Images', other: 'Other' };
 const typeRows = Object.entries(typeLabels)
   .map(([key, label]) => ({ label, ...(totalSizes[key] || { raw: 0, gzipped: 0 }) }))
@@ -44,13 +44,13 @@ const routeRows = Object.entries(routeAssets)
     <section>
       <p>
         Large language models make it cheap to build software fitted exactly to
-        the job at hand. Widely-used frameworks are great, but when you don't
+        the job at hand. Widely used frameworks are great, but when you don't
         need all their features, dropping down to something simpler is now easy.
-        So this site is completely static — no server-side rendering, nothing
-        computed per request — and kept deliberately small: every page's code
-        comes in under 60&nbsp;kB, and the fully static pages, just markup with
-        no JavaScript, weigh only a kilobyte or two. The numbers below are
-        regenerated on every build.
+        So the site is completely static with no server side rendering, no
+        middleware frameworks, nothing computed per request, and everything is
+        kept small: every page's code comes in under 60&nbsp;kB, and the fully
+        static pages, just markup with no JavaScript, weigh only a kilobyte or
+        two. The numbers below are regenerated on every build.
       </p>
 
       <p class="hero">
@@ -116,7 +116,7 @@ const routeRows = Object.entries(routeAssets)
         Each page counts only the HTML and JavaScript it actually loads, so
         fully static pages stay tiny; the pages with interactive islands
         (<code>/</code>, <code>/sports</code>) also pull a shared ~44&nbsp;kB
-        React bundle. Images aren't included here — they're in the site total
+        React bundle. Images aren't included here; they're in the site total
         above. <code>/posts</code> rolls up all blog posts.
       </p>
     </section>

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -43,8 +43,13 @@ const routeRows = Object.entries(routeAssets)
     <h1 class="headingXl">{title}</h1>
     <section>
       <p>
-        This site is static — plain HTML built ahead of time, no server doing
-        work per request. Here's exactly how small that makes it. Numbers are
+        Large language models make it cheap to build software fitted exactly to
+        the job at hand. Widely-used frameworks are great, but when you don't
+        need all their features, dropping down to something simpler is now easy.
+        So this site is completely static — no server-side rendering, nothing
+        computed per request — and kept deliberately small: every page's code
+        comes in under 60&nbsp;kB, and the fully static pages, just markup with
+        no JavaScript, weigh only a kilobyte or two. The numbers below are
         regenerated on every build.
       </p>
 
@@ -108,9 +113,11 @@ const routeRows = Object.entries(routeAssets)
         </tbody>
       </table>
       <p class="lightText note">
-        Shared <code>_astro</code> bundles (the bit of JavaScript that hydrates
-        interactive islands) are counted into every page that could load them,
-        so per-page totals overlap. <code>/posts</code> rolls up all blog posts.
+        Each page counts only the HTML and JavaScript it actually loads, so
+        fully static pages stay tiny; the pages with interactive islands
+        (<code>/</code>, <code>/sports</code>) also pull a shared ~44&nbsp;kB
+        React bundle. Images aren't included here — they're in the site total
+        above. <code>/posts</code> rolls up all blog posts.
       </p>
     </section>
   </article>

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -1,0 +1,157 @@
+---
+import Layout from '../layouts/Layout.astro';
+import buildStats from '../data/build-stats.json';
+
+const title = "Site Stats";
+const description = "How tiny this static site really is.";
+
+// Format a byte count into human-readable units (binary KB/MB).
+const formatBytes = (bytes) => {
+  if (!bytes) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+const formatDate = (iso) =>
+  new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(iso));
+
+const { totalSizes, routeAssets, postCount, fileCount, buildTimestamp, gitCommitSha } = buildStats;
+const inlinedCss = totalSizes.inlinedCss; // added 2026-05; may be absent in older builds
+const shortSha = gitCommitSha ? gitCommitSha.slice(0, 7) : null;
+
+// By-type rows for the main breakdown. The literal `css` bucket is omitted —
+// Astro inlines CSS into <style> tags, so it always reads 0; the real number
+// is surfaced separately as inlinedCss below.
+const typeLabels = { html: 'HTML', js: 'JavaScript', images: 'Images', other: 'Other' };
+const typeRows = Object.entries(typeLabels)
+  .map(([key, label]) => ({ label, ...(totalSizes[key] || { raw: 0, gzipped: 0 }) }))
+  .filter((row) => row.raw > 0);
+
+// Per-route rows, largest gzipped footprint first.
+const routeRows = Object.entries(routeAssets)
+  .map(([route, stats]) => ({ route, ...stats.total }))
+  .sort((a, b) => b.gzipped - a.gzipped);
+---
+
+<Layout title={title} description={description}>
+  <article>
+    <h1 class="headingXl">{title}</h1>
+    <section>
+      <p>
+        This site is static — plain HTML built ahead of time, no server doing
+        work per request. Here's exactly how small that makes it. Numbers are
+        regenerated on every build.
+      </p>
+
+      <p class="hero">
+        Whole site: <strong>{formatBytes(totalSizes.total.gzipped)}</strong> gzipped
+        <span class="lightText">({formatBytes(totalSizes.total.raw)} raw)</span>
+        across {fileCount} files.
+      </p>
+
+      <p class="lightText meta">
+        {postCount} blog posts · built {formatDate(buildTimestamp)}
+        {shortSha && (
+          <> · commit <a href={`https://github.com/mjelgart/melgart.net/commit/${gitCommitSha}`} target="_blank" rel="noopener">{shortSha}</a></>
+        )}
+      </p>
+    </section>
+
+    <section>
+      <h2 class="headingLg">By file type</h2>
+      <table>
+        <thead>
+          <tr><th>Type</th><th>Gzipped</th><th>Raw</th></tr>
+        </thead>
+        <tbody>
+          {typeRows.map((row) => (
+            <tr>
+              <td>{row.label}</td>
+              <td>{formatBytes(row.gzipped)}</td>
+              <td class="lightText">{formatBytes(row.raw)}</td>
+            </tr>
+          ))}
+          <tr class="totalRow">
+            <td>Total</td>
+            <td>{formatBytes(totalSizes.total.gzipped)}</td>
+            <td class="lightText">{formatBytes(totalSizes.total.raw)}</td>
+          </tr>
+        </tbody>
+      </table>
+      {inlinedCss && (
+        <p class="lightText note">
+          CSS is inlined into the HTML (no separate stylesheet requests):
+          {' '}{formatBytes(inlinedCss.gzipped)} gzipped, already counted within HTML above.
+        </p>
+      )}
+    </section>
+
+    <section>
+      <h2 class="headingLg">By page</h2>
+      <table>
+        <thead>
+          <tr><th>Route</th><th>Gzipped</th><th>Raw</th></tr>
+        </thead>
+        <tbody>
+          {routeRows.map((row) => (
+            <tr>
+              <td>{row.route}</td>
+              <td>{formatBytes(row.gzipped)}</td>
+              <td class="lightText">{formatBytes(row.raw)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p class="lightText note">
+        Shared <code>_astro</code> bundles (the bit of JavaScript that hydrates
+        interactive islands) are counted into every page that could load them,
+        so per-page totals overlap. <code>/posts</code> rolls up all blog posts.
+      </p>
+    </section>
+  </article>
+</Layout>
+
+<style>
+  .hero {
+    font-size: 1.3rem;
+    margin: 1.5rem 0 0.5rem;
+  }
+
+  .meta {
+    margin-top: 0;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5rem 0;
+  }
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.4rem 0.75rem 0.4rem 0;
+    border-bottom: 1px solid #ddd;
+  }
+
+  th + th,
+  td + td {
+    text-align: right;
+  }
+
+  .totalRow td {
+    border-top: 2px solid #999;
+    border-bottom: none;
+    font-weight: bold;
+  }
+
+  .note {
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
+  }
+</style>


### PR DESCRIPTION
## What

Adds a public `/stats` page showing how small this static site is, and fixes the per-route data that feeds it.

### `/stats` page (`src/pages/stats.astro`)
Reads `src/data/build-stats.json` (regenerated each build) and renders:
- **Hero:** total gzipped footprint (~1.01 MB, dominated by images) with raw alongside and file count
- **Meta:** post count, build date, short git SHA linked to the commit
- **By file type:** HTML / JavaScript / Images + total. Inlined CSS is surfaced as a separate note (Astro inlines `<style>`, so the literal `css` bucket reads 0 — the real ~1.2 KB gzipped is noted as a subset of HTML)
- **By page:** per-route gzipped/raw, sorted largest first, with a footnote that shared `_astro` bundles are counted into every page and that `/posts` rolls up all blog posts

Linked from the homepage **Extras** list.

### Route heuristic fix (`scripts/build-stats.mjs`)
`TRACKED_ROUTES` and `getRouteFromPath` didn't match Astro's directory-style output (`route/index.html`), so only `/` and `/sports` ever received data; `/blog` and `/search` (which don't exist) stayed at zero. Now:
- `TRACKED_ROUTES` = the real pages (`/`, `/posts`, `/sports`, `/saved-on-hosting`, `/stats`)
- `getRouteFromPath` strips a trailing `/index.html`, maps the page directory to its route, and rolls `posts/<slug>` up into `/posts`

## Verification
- `npm run build` regenerates `build-stats.json` with all five routes populated and `inlinedCss` present
- `npm run test:run` — all tests pass
- Rendered `/stats` spot-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)