### PR TITLE
content: note Next.js->Astro migration on stats page

### DIFF
--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -46,10 +46,10 @@ const routeRows = Object.entries(routeAssets)
         Large language models make it cheap to build software fitted exactly to
         the job at hand. Widely used frameworks are great, but when you don't
         need all their features, dropping down to something simpler is now easy.
-        So the site is completely static with no server side rendering, no
-        middleware frameworks, nothing computed per request, and everything is
-        kept small: every page's code comes in under 60&nbsp;kB, and the fully
-        static pages, just markup with no JavaScript, weigh only a kilobyte or
+        So in 2026, I migrated the site off Next.js onto Astro. It's still completely 
+        static with no server side rendering, nothing computed per request, but 
+        also now no unnecessary middleware. This also makes everything quite small: every page's code comes in under 60&nbsp;kB, and the fully
+        static pages (no JS in many cases!) weigh only a kilobyte or
         two. The numbers below are regenerated on every build.
       </p>
 


### PR DESCRIPTION
Prose edit to the intro paragraph on `/stats`: notes that the site migrated off Next.js onto Astro in 2026, and tweaks the "small pages" wording (no JS in many cases).

Content-only change to `src/pages/stats.astro` — no logic or build changes.

## Verification
- `npm run build` (astro build + build-stats.mjs + pagefind) → clean, `/stats` page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)